### PR TITLE
add location control

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
         "sourceType": "module"
     },
     "globals": {
-        "document": true
+        "document": true,
+        "navigator": true
     },
     "env": {
         "jest": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@problematy/goodmap",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "engines": {
         "node": ">=16.0.0"
     },

--- a/src/components/Map/components/LocationControl/LocationControl.jsx
+++ b/src/components/Map/components/LocationControl/LocationControl.jsx
@@ -1,0 +1,40 @@
+import Leaflet from 'leaflet';
+
+const LocationIcon = () => {
+    const icon = document.createElement('img');
+    icon.style.width = '22px';
+    icon.style.height = '22px';
+    icon.src =
+        'https://cdn3.iconfinder.com/data/icons/google-material-design-icons/48/ic_my_location_48px-512.png';
+
+    return icon;
+};
+
+Leaflet.Control.Button = Leaflet.Control.extend({
+    options: {
+        position: 'bottomright',
+    },
+
+    onLocationFoundCallback: (coordinates, map) =>
+        map.flyTo([coordinates.coords.latitude, coordinates.coords.longitude], 15),
+
+    onAdd: function (map) {
+        const container = Leaflet.DomUtil.create('div', 'leaflet-bar leaflet-control');
+        const button = Leaflet.DomUtil.create('a', 'leaflet-control-button', container);
+        const locationIcon = LocationIcon();
+
+        container.title = 'Twoja lokalizacja';
+        button.appendChild(locationIcon);
+
+        Leaflet.DomEvent.disableClickPropagation(button);
+        Leaflet.DomEvent.on(button, 'click', () => {
+            navigator.geolocation.getCurrentPosition(coordinates =>
+                this.onLocationFoundCallback(coordinates, map),
+            );
+        });
+
+        return container;
+    },
+
+    onRemove: function () {},
+});

--- a/src/components/Map/createBaseMap.js
+++ b/src/components/Map/createBaseMap.js
@@ -1,6 +1,7 @@
 import Leaflet from 'leaflet';
 import { UserLocationMarker } from './components/UserLocationMarker/UserLocationMarker';
 import { mapConfig } from './map.config';
+import './components/LocationControl/LocationControl';
 
 export function createBaseMap(onLocationFound) {
     const map = Leaflet.map('map').setView(
@@ -9,6 +10,7 @@ export function createBaseMap(onLocationFound) {
     );
     const locationMarker = UserLocationMarker(mapConfig.initialMapCoordinates);
     const cMarker = Leaflet.circle(mapConfig.initialMapCoordinates, 2);
+    const locationControl = new Leaflet.Control.Button();
     const mapBase = Leaflet.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: mapConfig.maxMapZoom,
         attribution:
@@ -22,6 +24,7 @@ export function createBaseMap(onLocationFound) {
     });
     map.locate({ setView: false, watch: true, maxZoom: 16 });
 
+    locationControl.addTo(map);
     locationMarker.addTo(map);
     cMarker.addTo(map);
 


### PR DESCRIPTION
There is no unit test for this component as it is fully dependent on Leaflet and browser geolocation API, and because of this there would be plenty of mocking and this case suit would be pretty useless. My proposition is to cover this in suit of e2e or integration test for whole map component.

There was mention of problem with Mozilla Firefox not saving permission on locating user. On macOS I could not reproduce. After selecting remember decision I did not get a popup on new enter.

closes #23