### PR TITLE
Updated: more clear build+run steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ If you want to use compiled version you can use cdn here:
 
 # Development
 
-To build static version you can:
+To build and run static version follow these steps:
 
-- `npm run build` - which builds production ready version
-- `npm run dev-build` - which is useful in debugging
-
-To run development server version use `npm run serve`
+1. `npm install` -- install all the dependencies in your project,
+2. building:
+   - `npm run build` -- which builds production ready version,
+   - `npm run dev-build` -- which is useful in debugging,
+3. `npm run serve` -- run development server version.


### PR DESCRIPTION
This might help someone who is not expected to know NPM or will not attempt to develop the app, but may want to just build the app on local machine during QA session.