### PR TITLE
feat: add proper aria-labels for filter

### DIFF
--- a/src/components/FiltersForm/components/FilterFormCategory.jsx
+++ b/src/components/FiltersForm/components/FilterFormCategory.jsx
@@ -7,8 +7,14 @@ export const FilterFormCategory = ({ filtersData, onClick }) => {
     const subcategoryData = filtersData[1];
 
     return (
-        <div key={`${categoryData[0]} ${categoryData[1]}`}>
-            <span> {categoryData[1]}</span>
+        <div
+            key={`${categoryData[0]} ${categoryData[1]}`}
+            aria-labelledby={`filter-label-${categoryData[0]}-${categoryData[1]}`}
+        >
+            <span id={`filter-label-${categoryData[0]}-${categoryData[1]}`}>
+                {' '}
+                {categoryData[1]}
+            </span>
             {subcategoryData.map(([name, translation]) => (
                 <Checkbox
                     key={name}

--- a/tests/snapshots/FiltersForm.test.jsx
+++ b/tests/snapshots/FiltersForm.test.jsx
@@ -18,8 +18,12 @@ test('Creates good filter_form box', () => {
     expect(asFragment()).toMatchInlineSnapshot(`
 <DocumentFragment>
   <form>
-    <div>
-      <span>
+    <div
+      aria-labelledby="filter-label-types-typy"
+    >
+      <span
+        id="filter-label-types-typy"
+      >
          typy
       </span>
       <div


### PR DESCRIPTION
Adds proper aria-labels for filter form to prevent seeing everything as one sentence

see: https://github.com/Problematy/goodmap/issues/87