### PR TITLE
FIX: Fit details in Dialog box on mobile in a better way

### DIFF
--- a/src/components/MarkerPopup/LocationDetails.jsx
+++ b/src/components/MarkerPopup/LocationDetails.jsx
@@ -38,9 +38,8 @@ const NavigateMeButton = ({ place }) => (
         <p
             style={{
                 ...buttonStyleSmall,
-                // width: '80%',
-                // marginTop: '5px', // Set top margin
-                // marginBottom: '10px', // Set bottom margin
+                marginTop: '8px',
+                marginBottom: '8px',
                 justifyContent: 'center',
                 display: 'flex',
             }}
@@ -73,9 +72,11 @@ const LocationDetails = ({ place }) => {
                 style={{
                     display: 'grid',
                     gridTemplateColumns: '100px 1fr',
-                    columnGap: '5px',
-                    rowGap: '2px',
-                    margin: '1px 5px',
+                    columnGap: '10px',
+                    rowGap: '10px',
+                    margin: '5px 5px',
+                    marginLeft: '10px',
+                    marginRight: '10px',
                     alignItems: 'start',
                     fontSize: 12,
                 }}
@@ -136,7 +137,16 @@ export const LocationDetailsBox = ({ place }) => {
                 {isMobile && <NavigateMeButton place={place} />}
             </div>
 
-            <p onClick={toggleForm} style={{ cursor: 'pointer', textAlign: 'right', color: 'red' }}>
+            <p
+                onClick={toggleForm}
+                style={{
+                    cursor: 'pointer',
+                    textAlign: 'right',
+                    color: 'red',
+                    marginTop: '5px',
+                    marginBottom: '5px',
+                }}
+            >
                 {t('ReportIssueButton')}
             </p>
             {showForm && <ReportProblemForm placeId={place.metadata.UUID} />}

--- a/src/components/MarkerPopup/LocationDetails.jsx
+++ b/src/components/MarkerPopup/LocationDetails.jsx
@@ -33,11 +33,7 @@ LocationDetailsValue.propTypes = {
 const NavigateMeButton = ({ place }) => (
     <a
         href={`geo:${place.position[0]},${place.position[1]}?q=${place.position[0]},${place.position[1]}`}
-        style={{ textDecoration: 'none',
-            alignItems: 'center',
-            height: '20%'
-        }}
-
+        style={{ textDecoration: 'none', alignItems: 'center', height: '20%' }}
     >
         <p
             style={{

--- a/src/components/MarkerPopup/LocationDetails.jsx
+++ b/src/components/MarkerPopup/LocationDetails.jsx
@@ -33,14 +33,20 @@ LocationDetailsValue.propTypes = {
 const NavigateMeButton = ({ place }) => (
     <a
         href={`geo:${place.position[0]},${place.position[1]}?q=${place.position[0]},${place.position[1]}`}
-        style={{ textDecoration: 'none' }}
+        style={{ textDecoration: 'none',
+            alignItems: 'center',
+            height: '20%'
+        }}
+
     >
         <p
             style={{
                 ...buttonStyleSmall,
+                // width: '80%',
+                // marginTop: '5px', // Set top margin
+                // marginBottom: '10px', // Set bottom margin
                 justifyContent: 'center',
                 display: 'flex',
-                alignItems: 'center',
             }}
         >
             <ExploreIcon style={{ color: 'white', marginRight: '10px' }} />
@@ -71,9 +77,9 @@ const LocationDetails = ({ place }) => {
                 style={{
                     display: 'grid',
                     gridTemplateColumns: '100px 1fr',
-                    columnGap: '10px',
-                    rowGap: '5px',
-                    margin: '10px 25px',
+                    columnGap: '5px',
+                    rowGap: '2px',
+                    margin: '1px 5px',
                     alignItems: 'start',
                     fontSize: 12,
                 }}
@@ -122,7 +128,17 @@ export const LocationDetailsBox = ({ place }) => {
         <React.Fragment>
             <LocationDetails place={place} />
 
-            {isMobile && <NavigateMeButton place={place} />}
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    marginRight: 25,
+                    marginLeft: 25,
+                    marginTop: 1,
+                }}
+            >
+                {isMobile && <NavigateMeButton place={place} />}
+            </div>
 
             <p onClick={toggleForm} style={{ cursor: 'pointer', textAlign: 'right', color: 'red' }}>
                 {t('ReportIssueButton')}

--- a/src/components/MarkerPopup/MobilePopup.jsx
+++ b/src/components/MarkerPopup/MobilePopup.jsx
@@ -51,12 +51,13 @@ export const MobilePopup = ({ children }) => {
                     bottom: 0,
                     margin: 0,
                     width: '100%',
-                    maxHeight: '50%',
+                    maxHeight: '60%',
                     borderRadius: '16px 16px 0 0',
+                    padding: '1px 1px'
                 },
             }}
         >
-            <DialogTitle style={{ textAlign: 'center', padding: '8px 16px' }}>
+            <DialogTitle style={{ textAlign: 'center', padding: '2px 16px' }}>
                 <IconButton
                     aria-label="close"
                     onClick={handleClose}
@@ -65,7 +66,7 @@ export const MobilePopup = ({ children }) => {
                     <CloseIcon />
                 </IconButton>
             </DialogTitle>
-            <DialogContent>{children}</DialogContent>
+            <DialogContent sx={{ padding: '8px' }}>{children}</DialogContent>
         </Dialog>
     );
 };

--- a/src/components/MarkerPopup/MobilePopup.jsx
+++ b/src/components/MarkerPopup/MobilePopup.jsx
@@ -51,7 +51,7 @@ export const MobilePopup = ({ children }) => {
                     bottom: 0,
                     margin: 0,
                     width: '100%',
-                    maxHeight: '60%',
+                    maxHeight: '90%',
                     borderRadius: '16px 16px 0 0',
                     padding: '1px 1px',
                 },

--- a/src/components/MarkerPopup/MobilePopup.jsx
+++ b/src/components/MarkerPopup/MobilePopup.jsx
@@ -53,7 +53,7 @@ export const MobilePopup = ({ children }) => {
                     width: '100%',
                     maxHeight: '60%',
                     borderRadius: '16px 16px 0 0',
-                    padding: '1px 1px'
+                    padding: '1px 1px',
                 },
             }}
         >


### PR DESCRIPTION
Closes https://github.com/Problematy/goodmap/issues/181

I decided to make the `Dialog` box more flexible. It adjusts its size depending on the content, but up to 90% of fullscreen height.
This should suffice. When testing on real points, the `Dialog` box was about 60% high. After opening "report a problem" form, it reached its maximum size.