### PR TITLE
fix: PluginSlot props are now required and tests are added

### DIFF
--- a/src/plugins/PluginSlot.jsx
+++ b/src/plugins/PluginSlot.jsx
@@ -19,4 +19,8 @@ PluginSlot.propTypes = {
     props: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
+PluginSlot.defaultProps = {
+    props: {},
+};
+
 export default PluginSlot;

--- a/src/plugins/PluginSlot.jsx
+++ b/src/plugins/PluginSlot.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { getPlugin, subscribe } from './pluginRegistry';
 
-const PluginSlot = ({ scope, props: componentProps = {} }) => {
+const PluginSlot = ({ scope, props: componentProps }) => {
     const [Component, setComponent] = useState(() => getPlugin(scope));
 
     useEffect(() => subscribe(() => setComponent(() => getPlugin(scope))), [scope]);
@@ -16,11 +16,7 @@ const PluginSlot = ({ scope, props: componentProps = {} }) => {
 
 PluginSlot.propTypes = {
     scope: PropTypes.string.isRequired,
-    props: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-};
-
-PluginSlot.defaultProps = {
-    props: {},
+    props: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 };
 
 export default PluginSlot;

--- a/src/plugins/PluginSlot.jsx
+++ b/src/plugins/PluginSlot.jsx
@@ -19,8 +19,4 @@ PluginSlot.propTypes = {
     props: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
-PluginSlot.defaultProps = {
-    props: {},
-};
-
 export default PluginSlot;

--- a/src/plugins/PluginSlot.jsx
+++ b/src/plugins/PluginSlot.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { getPlugin, subscribe } from './pluginRegistry';
 
-const PluginSlot = ({ scope, props: componentProps }) => {
+const PluginSlot = ({ scope, props: componentProps = {} }) => {
     const [Component, setComponent] = useState(() => getPlugin(scope));
 
     useEffect(() => subscribe(() => setComponent(() => getPlugin(scope))), [scope]);
@@ -17,10 +17,6 @@ const PluginSlot = ({ scope, props: componentProps }) => {
 PluginSlot.propTypes = {
     scope: PropTypes.string.isRequired,
     props: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-};
-
-PluginSlot.defaultProps = {
-    props: {},
 };
 
 export default PluginSlot;

--- a/tests/MarkerPopup/LocationDetailsBox.test.jsx
+++ b/tests/MarkerPopup/LocationDetailsBox.test.jsx
@@ -90,6 +90,18 @@ describe('should render marker popup correctly', () => {
                 ).not.toThrow();
             });
         });
+
+        describe('should handle plugin fields', () => {
+            it('renders the field label for a scoped plugin field even when plugin is not loaded', () => {
+                const placeWithPlugin = {
+                    ...correctMarkerData,
+                    data: [['promocode', { scope: 'promocode', code: 'U1VN', text: 'Get it' }]],
+                    metadata: { uuid: 'test-uuid' },
+                };
+                render(<LocationDetailsBox place={placeWithPlugin} />);
+                expect(screen.getByText('promocode')).toBeInTheDocument();
+            });
+        });
     });
 });
 

--- a/tests/plugins/PluginSlot.test.jsx
+++ b/tests/plugins/PluginSlot.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import '@testing-library/jest-dom';
 import { render, screen, act } from '@testing-library/react';
 import PluginSlot from '../../src/plugins/PluginSlot';
@@ -12,6 +13,7 @@ describe('PluginSlot', () => {
 
     it('renders the registered component with given props', () => {
         const TestComponent = ({ message }) => <span>{message}</span>;
+        TestComponent.propTypes = { message: PropTypes.string.isRequired };
         act(() => registerPlugin('test-scope', TestComponent));
 
         render(<PluginSlot scope="test-scope" props={{ message: 'hello plugin' }} />);

--- a/tests/plugins/PluginSlot.test.jsx
+++ b/tests/plugins/PluginSlot.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, act } from '@testing-library/react';
+import PluginSlot from '../../src/plugins/PluginSlot';
+import { registerPlugin } from '../../src/plugins/pluginRegistry';
+
+describe('PluginSlot', () => {
+    it('renders nothing when plugin is not registered', () => {
+        const { container } = render(<PluginSlot scope="unregistered-scope" props={{}} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders the registered component with given props', () => {
+        const TestComponent = ({ message }) => <span>{message}</span>;
+        act(() => registerPlugin('test-scope', TestComponent));
+
+        render(<PluginSlot scope="test-scope" props={{ message: 'hello plugin' }} />);
+        expect(screen.getByText('hello plugin')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin components now render correctly when property data is missing.
  * Plugin slots now require explicit properties instead of relying on implicit defaults.

* **Tests**
  * Added tests verifying plugin slot behavior for registered and unregistered scopes.
  * Added test coverage for rendering scoped field labels with incomplete data states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Problematy/goodmap-frontend/pull/157)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Problematy/goodmap-frontend/pull/157)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->